### PR TITLE
Check if prettier.config.* exists

### DIFF
--- a/lua/prettier/utils.lua
+++ b/lua/prettier/utils.lua
@@ -15,7 +15,7 @@ local function config_file_exists()
 
   if project_root then
     return vim.tbl_count(vim.fn.glob(".prettierrc*", true, true)) > 0 or
-      vim.tbl_count(vim.fn.glob("prettier.config.js", true, true)) > 0
+      vim.tbl_count(vim.fn.glob("prettier.config.*", true, true)) > 0
   end
 
   return false

--- a/lua/prettier/utils.lua
+++ b/lua/prettier/utils.lua
@@ -14,7 +14,8 @@ local function config_file_exists()
   local project_root = get_working_directory()
 
   if project_root then
-    return vim.tbl_count(vim.fn.glob(".prettierrc*", true, true)) > 0
+    return vim.tbl_count(vim.fn.glob(".prettierrc*", true, true)) > 0 or
+      vim.tbl_count(vim.fn.glob("prettier.config.js", true, true)) > 0
   end
 
   return false

--- a/lua/prettier/utils.lua
+++ b/lua/prettier/utils.lua
@@ -14,8 +14,8 @@ local function config_file_exists()
   local project_root = get_working_directory()
 
   if project_root then
-    return vim.tbl_count(vim.fn.glob(".prettierrc*", true, true)) > 0 or
-      vim.tbl_count(vim.fn.glob("prettier.config.*", true, true)) > 0
+    return vim.tbl_count(vim.fn.glob(".prettierrc*", true, true)) > 0
+      or vim.tbl_count(vim.fn.glob("prettier.config.*", true, true)) > 0
   end
 
   return false


### PR DESCRIPTION
Hi,

`prettier.config.js` and `prettier.config.cjs` are also recognized as a configuration file in Prettier.
That is mentioned in the documentation: https://prettier.io/docs/en/configuration.html
