### PR TITLE
fix: updated null-ls format on save setup instructions for latest neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,33 @@ For Latest Neovim:
 ```lua
 local null_ls = require("null-ls")
 
+local group = vim.api.nvim_create_augroup("lsp_format_on_save", { clear = false })
+local event = "BufWritePre" -- or "BufWritePost"
+local async = event == "BufWritePost"
+
 null_ls.setup({
   on_attach = function(client, bufnr)
-    if client.server_capabilities.documentFormattingProvider then
-      vim.cmd("nnoremap <silent><buffer> <Leader>f :lua vim.lsp.buf.formatting()<CR>")
+    if client.supports_method("textDocument/formatting") then
+      vim.keymap.set("n", "<Leader>f", function()
+        vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
+      end, { buffer = bufnr, desc = "[lsp] format" })
 
       -- format on save
-      vim.cmd("autocmd BufWritePost <buffer> lua vim.lsp.buf.formatting()")
+      vim.api.nvim_clear_autocmds({ buffer = bufnr, group = group })
+      vim.api.nvim_create_autocmd(event, {
+        buffer = bufnr,
+        group = group,
+        callback = function()
+          vim.lsp.buf.format({ bufnr = bufnr, async = async })
+        end,
+        desc = "[lsp] format on save",
+      })
     end
 
-    if client.server_capabilities.documentRangeFormattingProvider then
-      vim.cmd("xnoremap <silent><buffer> <Leader>f :lua vim.lsp.buf.range_formatting({})<CR>")
+    if client.supports_method("textDocument/rangeFormatting") then
+      vim.keymap.set("x", "<Leader>f", function()
+        vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
+      end, { buffer = bufnr, desc = "[lsp] format" })
     end
   end,
 })


### PR DESCRIPTION
Fixes #18 
Updated null-ls setup instructions for latest neovim to fix the error below which is mentioned in issue #18 
```
Error detected while processing BufWritePost Autocommands for "<buffer=3>":
E5108: Error executing lua [string ":lua"]:1: attempt to call field 'formatting' (a nil value)
stack traceback:
        [string ":lua"]:1: in main chunk
```
The code is from null-ls docs [here](https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Formatting-on-save)
