### PR TITLE
fix: nil pointer error when user_options not provided

### DIFF
--- a/lua/prettier/options.lua
+++ b/lua/prettier/options.lua
@@ -117,7 +117,7 @@ function M.setup(user_options)
     return
   end
 
-  user_options = u.tbl_flatten(user_options, should_flatten)
+  user_options = u.tbl_flatten(user_options or {}, should_flatten)
 
   validate_options(user_options)
 


### PR DESCRIPTION
After my last PR I removed the options as I'm now using the defaults but get `nil` pointer error if don't supply empty table to `setup`. You may want to fix it differently but this seems to work. Thanks again.

```lua
require('pretter').setup()
```